### PR TITLE
Fix plugin activation by sharing @jupyter/chat package

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,13 @@
             }
         },
         "extension": true,
-        "outputDir": "jupyter_ai_chat_commands/labextension"
+        "outputDir": "jupyter_ai_chat_commands/labextension",
+        "sharedPackages": {
+            "@jupyter/chat": {
+                "bundled": false,
+                "singleton": true
+            }
+        }
     },
     "eslintIgnore": [
         "node_modules",


### PR DESCRIPTION
Resolves plugin activation errors where IChatCommandRegistry provider could not be found. Configures @jupyter/chat as a shared singleton package to ensure all extensions use the same instance.

Fixes #7