### PR TITLE
Add PersonaCommandProvider for /command autocomplete

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { URLExt } from '@jupyterlab/coreutils';
+import { ServerConnection } from '@jupyterlab/services';
+
+/**
+ * Metadata for a single `/command` registered on a persona.
+ */
+export type IPersonaCommand = {
+  name: string;
+  description: string;
+};
+
+type IPersonaCommandsResponse = {
+  commands: IPersonaCommand[];
+};
+
+/**
+ * Fetches the list of `/commands` registered on the given persona for the chat
+ * at `chatPath`. If `personaMentionName` is `null`, the server returns the
+ * commands of the chat's last-mentioned persona (falling back to the default
+ * persona). Returns an empty array on any error so that the autocomplete UI
+ * can degrade gracefully.
+ */
+export async function getPersonaCommands(
+  chatPath: string,
+  personaMentionName: string | null = null
+): Promise<IPersonaCommand[]> {
+  const settings = ServerConnection.makeSettings();
+  const params = new URLSearchParams({ chat_path: chatPath });
+  if (personaMentionName !== null) {
+    params.set('persona', personaMentionName);
+  }
+  const requestUrl =
+    URLExt.join(settings.baseUrl, 'api/ai/persona-commands') +
+    `?${params.toString()}`;
+
+  let response: Response;
+  try {
+    response = await ServerConnection.makeRequest(requestUrl, {}, settings);
+  } catch (e) {
+    console.warn('Error retrieving persona commands: ', e);
+    return [];
+  }
+
+  if (!response.ok) {
+    console.warn(
+      `Persona commands endpoint returned ${response.status} ${response.statusText}`
+    );
+    return [];
+  }
+
+  let data: IPersonaCommandsResponse;
+  try {
+    data = await response.json();
+  } catch (e) {
+    console.warn('Persona commands response was not valid JSON: ', e);
+    return [];
+  }
+
+  return data?.commands ?? [];
+}

--- a/src/chat-command-plugins/index.ts
+++ b/src/chat-command-plugins/index.ts
@@ -1,4 +1,9 @@
 import { fileCommandPlugin } from './file-command';
+import { personaCommandPlugin } from './persona-commands';
 import { slashCommandPlugin } from './slash-commands';
 
-export const chatCommandPlugins = [fileCommandPlugin, slashCommandPlugin];
+export const chatCommandPlugins = [
+  fileCommandPlugin,
+  slashCommandPlugin,
+  personaCommandPlugin
+];

--- a/src/chat-command-plugins/persona-commands.tsx
+++ b/src/chat-command-plugins/persona-commands.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React from 'react';
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import {
+  IChatCommandProvider,
+  IChatCommandRegistry,
+  IInputModel,
+  ChatCommand
+} from '@jupyter/chat';
+import TerminalIcon from '@mui/icons-material/Terminal';
+
+import { getPersonaCommands } from '../api';
+
+const PERSONA_COMMAND_PROVIDER_ID =
+  '@jupyter-ai/chat-commands:persona-command-provider';
+
+/**
+ * Chat command provider that surfaces `/commands` registered by the persona
+ * `@`-mentioned in the current input.
+ *
+ * Trigger: the user's `currentWord` starts with `/` AND is the first non-space
+ * token after any leading `@-mention`. This lets users discover persona-scoped
+ * commands by typing `@persona /` at the start of the input.
+ *
+ * Submission is a no-op — the persona's `dispatch_command` runs server-side
+ * once the message reaches `PersonaManager._broadcast`.
+ */
+export class PersonaCommandProvider implements IChatCommandProvider {
+  public id: string = PERSONA_COMMAND_PROVIDER_ID;
+
+  async listCommandCompletions(
+    inputModel: IInputModel
+  ): Promise<ChatCommand[]> {
+    // Match the activation rules of the legacy SlashCommandProvider:
+    // suggestions only appear when the user's *current word* equals the first
+    // whitespace-delimited token of the input AND that token starts with `/`.
+    const value = inputModel.value ?? '';
+    const firstWord = getFirstWord(value);
+    if (inputModel.currentWord !== firstWord) {
+      return [];
+    }
+    if (!firstWord || !firstWord.startsWith('/')) {
+      return [];
+    }
+
+    const existingMentions = getExistingMentions(inputModel);
+    if (existingMentions.size > 1) {
+      return [];
+    }
+
+    const personaMentionName =
+      existingMentions.size === 1
+        ? (existingMentions.values().next().value ?? null)
+        : null;
+
+    // Use the chat context's name (file path) when available; fall back to an
+    // empty string so the server can resolve the active chat from the URL on
+    // its own. The server returns an empty list when it can't resolve.
+    const chatPath = inputModel.chatContext?.name ?? '';
+    const commands = await getPersonaCommands(chatPath, personaMentionName);
+
+    const suggestions: ChatCommand[] = [];
+    for (const cmd of commands) {
+      if (!cmd.name.startsWith(firstWord)) {
+        continue;
+      }
+      suggestions.push({
+        name: cmd.name,
+        providerId: this.id,
+        description: cmd.description,
+        icon: <TerminalIcon />,
+        spaceOnAccept: true
+      });
+    }
+    return suggestions;
+  }
+
+  async onSubmit(_inputModel: IInputModel): Promise<void> {
+    // No-op. Persona /commands are dispatched by the server-side
+    // PersonaManager when the message is routed.
+  }
+}
+
+function getExistingMentions(inputModel: IInputModel): Set<string> {
+  const matches = (inputModel.value ?? '').matchAll(/@([\w-]+)/g);
+  const names = new Set<string>();
+  for (const m of matches) {
+    if (m[1]) {
+      names.add(m[1]);
+    }
+  }
+  return names;
+}
+
+/**
+ * Returns the first whitespace-delimited token in `input`, or `null` if there
+ * is none. Mirrors the helper used by the legacy SlashCommandProvider so that
+ * activation rules stay consistent.
+ */
+function getFirstWord(input: string): string | null {
+  let start = 0;
+  while (start < input.length && /\s/.test(input[start])) {
+    start++;
+  }
+  let end = start;
+  while (end < input.length && !/\s/.test(input[end])) {
+    end++;
+  }
+  const firstWord = input.substring(start, end);
+  return firstWord ? firstWord : null;
+}
+
+export const personaCommandPlugin: JupyterFrontEndPlugin<void> = {
+  id: PERSONA_COMMAND_PROVIDER_ID,
+  description:
+    'Adds autocomplete for persona-scoped /commands in the Jupyter AI chat input.',
+  autoStart: true,
+  requires: [IChatCommandRegistry],
+  activate: (_app, registry: IChatCommandRegistry) => {
+    registry.addProvider(new PersonaCommandProvider());
+  }
+};

--- a/src/chat-command-plugins/persona-commands.tsx
+++ b/src/chat-command-plugins/persona-commands.tsx
@@ -35,15 +35,16 @@ export class PersonaCommandProvider implements IChatCommandProvider {
   async listCommandCompletions(
     inputModel: IInputModel
   ): Promise<ChatCommand[]> {
-    // Match the activation rules of the legacy SlashCommandProvider:
-    // suggestions only appear when the user's *current word* equals the first
-    // whitespace-delimited token of the input AND that token starts with `/`.
-    const value = inputModel.value ?? '';
-    const firstWord = getFirstWord(value);
-    if (inputModel.currentWord !== firstWord) {
+    // Suggestions only appear when the user's `currentWord` is the leading
+    // command token — i.e. it starts with `/` and the only thing in front of
+    // it is whitespace plus an optional sequence of `@-mention` tokens. This
+    // covers both `/<cmd>` and `@persona /<cmd>` shapes while staying out of
+    // the way of slashes mid-message.
+    const currentWord = inputModel.currentWord ?? '';
+    if (!currentWord.startsWith('/')) {
       return [];
     }
-    if (!firstWord || !firstWord.startsWith('/')) {
+    if (!isLeadingCommandPosition(inputModel.value, currentWord)) {
       return [];
     }
 
@@ -65,7 +66,7 @@ export class PersonaCommandProvider implements IChatCommandProvider {
 
     const suggestions: ChatCommand[] = [];
     for (const cmd of commands) {
-      if (!cmd.name.startsWith(firstWord)) {
+      if (!cmd.name.startsWith(currentWord)) {
         continue;
       }
       suggestions.push({
@@ -97,21 +98,27 @@ function getExistingMentions(inputModel: IInputModel): Set<string> {
 }
 
 /**
- * Returns the first whitespace-delimited token in `input`, or `null` if there
- * is none. Mirrors the helper used by the legacy SlashCommandProvider so that
- * activation rules stay consistent.
+ * Returns true if `currentWord` (a `/...` token) is the first non-whitespace
+ * token in `value` after stripping any sequence of leading `@mention` tokens.
+ * This is what makes `@persona /cmd` count as the leading command position
+ * even though `@persona` is technically the first whitespace-delimited word.
  */
-function getFirstWord(input: string): string | null {
-  let start = 0;
-  while (start < input.length && /\s/.test(input[start])) {
-    start++;
+function isLeadingCommandPosition(
+  value: string | undefined,
+  currentWord: string
+): boolean {
+  if (!value || !currentWord) {
+    return false;
   }
-  let end = start;
-  while (end < input.length && !/\s/.test(input[end])) {
-    end++;
+  let body = value.replace(/^\s+/, '');
+  while (true) {
+    const m = body.match(/^@[\w-]+\s+/);
+    if (!m) {
+      break;
+    }
+    body = body.slice(m[0].length);
   }
-  const firstWord = input.substring(start, end);
-  return firstWord ? firstWord : null;
+  return body.startsWith(currentWord);
 }
 
 export const personaCommandPlugin: JupyterFrontEndPlugin<void> = {

--- a/ui-tests/tests/persona-commands.spec.ts
+++ b/ui-tests/tests/persona-commands.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import {
+  expect,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
+import { User } from '@jupyterlab/services';
+import { UUID } from '@lumino/coreutils';
+import { Locator } from '@playwright/test';
+
+const FILENAME = 'persona-commands.chat';
+
+const USER: User.IUser = {
+  identity: {
+    username: UUID.uuid4(),
+    name: 'jovyan',
+    display_name: 'jovyan',
+    initials: 'JP',
+    color: 'var(--jp-collaborator-color1)'
+  },
+  permissions: {}
+};
+
+const openChat = async (
+  page: IJupyterLabPageFixture,
+  filename: string
+): Promise<Locator> => {
+  let panel = await page.activity.getPanelLocator(filename);
+  if (panel !== null && (await panel.count())) {
+    return panel;
+  }
+  await page.evaluate(async filepath => {
+    await window.jupyterapp.commands.execute('jupyterlab-chat:open', {
+      filepath
+    });
+  }, filename);
+  const splitPath = filename.split('/');
+  const tabName = splitPath[splitPath.length - 1];
+  await page.waitForCondition(
+    async () => await page.activity.isTabActive(tabName)
+  );
+  panel = await page.activity.getPanelLocator(tabName);
+  return panel as Locator;
+};
+
+test.use({
+  mockUser: USER
+});
+
+/**
+ * Verifies the @-mention /command platform: the chat-commands extension's
+ * `PersonaCommandProvider` fetches per-persona commands from
+ * `/api/ai/persona-commands` and surfaces them in the autocomplete dropdown
+ * when the user types `/` at the leading command position.
+ *
+ * The endpoint is mocked here so the test does not depend on a persona
+ * actually being registered with `@persona_command` in the running env.
+ */
+test.describe('#persona-commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+    await page.route(/api\/ai\/persona-commands/, async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          commands: [
+            { name: '/clear', description: 'Clear the conversation' },
+            { name: '/help', description: 'Show available commands' },
+            { name: '/login', description: 'Authenticate with the agent' }
+          ]
+        })
+      });
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(FILENAME)) {
+      await page.filebrowser.contents.deleteFile(FILENAME);
+    }
+  });
+
+  test('should list persona /commands when user types /', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.pressSequentially('/');
+
+    // The dropdown surfaces our 3 mocked commands (other slash-providers may
+    // contribute additional entries — assert by content, not exact count).
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(1);
+  });
+
+  test('should filter persona /commands by prefix', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.pressSequentially('/he');
+
+    // `/clear` and `/login` no longer match; only `/help` should remain among
+    // the persona commands. Other providers may still surface unrelated
+    // entries (e.g. emoji), so assert by inclusion.
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(0);
+  });
+
+  test('should not list persona /commands mid-message', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    // A `/` that is not the leading token must NOT trigger persona-command
+    // autocomplete — those commands only make sense at the start of input.
+    await input.pressSequentially('hello /he');
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(0);
+  });
+});

--- a/ui-tests/tests/persona-commands.spec.ts
+++ b/ui-tests/tests/persona-commands.spec.ts
@@ -131,4 +131,19 @@ test.describe('#persona-commands', () => {
     await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(0);
     await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(0);
   });
+
+  test('should list persona /commands after an @-mention', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    // The realistic flow: user types `@SomePersona ` then `/` to discover the
+    // commands that persona supports. Activation must still fire here.
+    await input.pressSequentially('@SomePersona /');
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
## Summary

Adds a new `IChatCommandProvider` (`PersonaCommandProvider`) that fetches per-persona `/commands` from the `/api/ai/persona-commands` endpoint introduced in [jupyter-ai-contrib/jupyter-ai-persona-manager#51](#https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/pull/51) and surfaces them in the chat-input autocomplete dropdown.

- Activates only when the user's `currentWord` starts with `/` AND that token is the *first* whitespace-delimited word of the input (optionally preceded by a single `@-mention`). Mid-message `/`s don't trigger it — those aren't commands.
- Resolves which persona to ask: zero mentions → server picks the chat's last-mentioned (falling back to the default) persona; one mention → that persona; >1 mentions → no completions (ambiguous).
- Submission is a no-op — actual dispatch happens server-side in `PersonaManager._broadcast`. This provider is purely autocomplete sugar, mirroring how the ACP slash-command provider works.

The icon is a generic terminal glyph (`@mui/icons-material/Terminal`) to distinguish persona commands from the existing chat-level slash commands (which use `Refresh`).


https://github.com/user-attachments/assets/efaf4765-d436-47a1-9546-c740d6ac5853


## Test plan

- [x] `tsc --noEmit` clean
- [x] Playwright UI test in [jupyterlab/jupyter-chat#XX](#) — 3/3 passing (full dropdown listing, prefix filtering, no-mid-message-trigger)
- [ ] Reviewer: type `@<persona> /` in chat with the [demo persona installed](#) — expect `/ping`, `/echo`, `/whoami`, `/help`
- [ ] Reviewer: verify the existing `/refresh-personas` still appears alongside persona commands

## Companion changes

- Backend: `jupyter-ai-contrib/jupyter-ai-persona-manager` — adds the `@persona_command` decorator, dispatcher, and the `/api/ai/persona-commands` endpoint.
- UI test: `jupyterlab/jupyter-chat` — Playwright spec exercising the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)